### PR TITLE
Install dependencies for hubot

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,6 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+# Set Binaries
+bin/hubot binary

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ Temporary Items
 # =================
 
 .vagrant/
+**/
+*
+.*

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The collective mind will guide Hayt.
 - [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 
 ### Goals
-- [ ] Support Hubot execution.
+- [x] Support Hubot execution.
 - [ ] Support mocha test execution.
 
 ### Workflow
@@ -26,7 +26,7 @@ The collective mind will guide Hayt.
 This will clone the `arrakis-hubot` repo locally, make your changes here with your favorite editor.
 When you're ready to test:
 ```
-> vagarnt ssh
+> vagrant ssh
 $ cd arrakis/arrakis-hubot
 $ bin/hubot
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The collective mind will guide Hayt.
 ### Workflow
 ```
 > git clone https://github.com/desert-planet/vagrant-hubot.git
+# If on windows you should set autocrlf to false.
+> git config --global core.autocrlf false
 > vagrant status
 ```
 This will clone the `arrakis-hubot` repo locally, make your changes here with your favorite editor.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 To aid in the development of Hayt, our robotic soul
 
 ### Personality
-This tool will construct with Windows as a host, and all else is second.
-
 This tool will provide a foundation for the soul to exist.
 
 It breaths life and tests is faith.
@@ -13,10 +11,23 @@ Contribution's will only be acceptable through pull requests.
 The collective mind will guide Hayt.
 
 ### Dependencies
-- Vagrant
-- VirtualBox
+- [Vagrant](https://www.vagrantup.com/downloads.html)
+- [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 
 ### Goals
 - [ ] Support Hubot execution.
 - [ ] Support mocha test execution.
-- [ ] Provide editing tools.
+
+### Workflow
+```
+> git clone git@github.com:desert-planet/vagrant-hubot.git
+> vagrant up
+```
+This will clone the `arrakis-hubot` repo locally, make your changes here with your favorite editor.
+When you're ready to test:
+```
+> vagarnt ssh
+$ cd arrakis/arrakis-hubot
+$ bin/hubot
+```
+Test your feature.

--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ The collective mind will guide Hayt.
 
 ### Workflow
 ```
-> git clone git@github.com:desert-planet/vagrant-hubot.git
-> vagrant up
+> git clone https://github.com/desert-planet/vagrant-hubot.git
+> vagrant status
 ```
 This will clone the `arrakis-hubot` repo locally, make your changes here with your favorite editor.
 When you're ready to test:
 ```
+> vagrant up
 > vagrant ssh
 $ cd arrakis/arrakis-hubot
 $ bin/hubot

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,20 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+#clone repos localy
+current_dir = File.dirname(__FILE__)
+
+repos = {
+  'arrakis-hubot' => 'git@github.com:desert-planet/arrakis-hubot.git'
+}
+
+repos.each_pair do |dir, repo|
+  unless File.exists?("#{current_dir}/#{dir}")
+    puts "Cloning #{repo} into #{current_dir}/#{dir}"
+    system("git clone #{repo} #{current_dir}/#{dir}")
+  end
+end
+
 Vagrant.configure(2) do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
@@ -14,8 +28,12 @@ Vagrant.configure(2) do |config|
 
   # So far vagrant-hubot/ is mapped to /vagrant. That's fine.
   # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder "./", "/home/vagrant/arrakis"
 
   # We're running this thing headless. No need for a gui currently.
+  config.vm.provider :virtualbox do |vb|
+    vb.gui = false
+  end
 
   # I could definitely consider doing this in the future.
   # config.push.define "atlas" do |push|
@@ -24,7 +42,7 @@ Vagrant.configure(2) do |config|
 
   # Just going to roll shell.
   config.vm.provision "shell", inline: <<-SHELL
-    sudo apt-get update
-    sudo apt-get install -y git build-essential nodejs
+    sudo apt-get update -qq
+    sudo apt-get install -y git build-essential nodejs nodejs-legacy npm coffeescript redis-server libgd2-xpm-dev libicu-dev 
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,5 +25,6 @@ Vagrant.configure(2) do |config|
   # Just going to roll shell.
   config.vm.provision "shell", inline: <<-SHELL
     sudo apt-get update
+    sudo apt-get install -y node-js
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 current_dir = File.dirname(__FILE__)
 
 repos = {
-  'arrakis-hubot' => 'https://github.com/desert-planet/vagrant-hubot.git'
+  'arrakis-hubot' => 'https://github.com/desert-planet/arrakis-hubot.git'
 }
 
 repos.each_pair do |dir, repo|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,6 @@ Vagrant.configure(2) do |config|
   # Just going to roll shell.
   config.vm.provision "shell", inline: <<-SHELL
     sudo apt-get update
-    sudo apt-get install -y node-js
+    sudo apt-get install -y git build-essential nodejs
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 current_dir = File.dirname(__FILE__)
 
 repos = {
-  'arrakis-hubot' => 'git@github.com:desert-planet/arrakis-hubot.git'
+  'arrakis-hubot' => 'https://github.com/desert-planet/vagrant-hubot.git'
 }
 
 repos.each_pair do |dir, repo|
@@ -43,6 +43,6 @@ Vagrant.configure(2) do |config|
   # Just going to roll shell.
   config.vm.provision "shell", inline: <<-SHELL
     sudo apt-get update -qq
-    sudo apt-get install -y git build-essential nodejs nodejs-legacy npm coffeescript redis-server libgd2-xpm-dev libicu-dev 
+    sudo apt-get install -y git build-essential nodejs nodejs-legacy npm coffeescript redis-server libgd2-xpm-dev libicu-dev
   SHELL
 end


### PR DESCRIPTION
The only commands I will be allowed to run by the end of this is

``` bash
> vagrant up
> vagrant ssh
$ git clone https://github.com/desert-planet/vagrant-hubot
$ cd vagrant-hubot
$ vagrant-hubot/bin/hubot
hubot> hubot roll 1d20
```

It should run if the dependencies are installed. The intention is that a later pull request implement these commands the repo pull itself. Then after that possibly support for mocha and hubot on path.
